### PR TITLE
Fixes sass namespace collisions in kanban and ang-exp mixin naming

### DIFF
--- a/src/app/ang-exp/ang-exp.component.html
+++ b/src/app/ang-exp/ang-exp.component.html
@@ -15,6 +15,7 @@
                                 (click)="drawer.close()"
                                 routerLink="drag-drop"
                                 class="nav-button"
+                                [class.focused]="true"
                         >
                             cdk Drag Drop
                         </button>

--- a/src/app/ang-exp/ang-exp.component.scss
+++ b/src/app/ang-exp/ang-exp.component.scss
@@ -42,6 +42,11 @@
                     padding: 0;
                 }
             }
+
+            .focused {
+                background-color: var(--ang-exp-primary-idle);
+                color: var(--ang-exp-on-primary-idle);
+            }
         }
     }
 

--- a/src/app/ang-exp/drag-drop/drag-drop.component.scss
+++ b/src/app/ang-exp/drag-drop/drag-drop.component.scss
@@ -27,7 +27,7 @@
     .drag-drop-container {
         @include global.border1;
         @include global.flexboxLayout(row, flex-start, stretch);
-        background-color: var(--background-2);
+        background-color: var(--ang-exp-background-2);
         box-sizing: border-box;
         height: calc(100vh - var(--size-nav-bar-height));
         margin: 0;

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -23,12 +23,12 @@
 
             .top-sidenav-container {
                 .heading {
-                    @include kanban.headingXLText;
+                    @include kanban.kanbanHeadingXLText;
                     margin: 34px 120px 54px 34px;
                 }
 
                 .nav-button {
-                    @include kanban.sidenavButtonStyles;
+                    @include kanban.kanbanSidenavButtonStyles;
                     @include global.flexboxLayout(row, flex-start, center);
 
                     mat-icon {
@@ -43,13 +43,13 @@
                 }
 
                 .all-boards {
-                    @include kanban.headingSText;
+                    @include kanban.kanbanHeadingSText;
                     padding: 0 16px;
                     text-transform: uppercase;
                 }
 
                 .create-new-board-button {
-                    @include kanban.headingMText;
+                    @include kanban.kanbanHeadingMText;
                     background-color: var(--dark-background-3);
                     color: var(--primary-idle);
                 }
@@ -76,7 +76,7 @@
                 }
 
                 .hide-sidebar-button {
-                    @include kanban.headingMText;
+                    @include kanban.kanbanHeadingMText;
                     @include global.flexboxLayout(row, center, center);
                     align-self: flex-start;
                     background-color: var(--background-3);
@@ -98,7 +98,7 @@
             position: relative;
     
             .show-sidenav-button {
-                @include kanban.mainButtonStyles(var(--kanban-primary-idle), var(--kanban-on-primary-idle), var(--size-button-tall));
+                @include kanban.kanbanMainButtonStyles(var(--kanban-primary-idle), var(--kanban-on-primary-idle), var(--size-button-tall));
                 border-top-left-radius: 0;
                 border-top-right-radius: 100px;
                 border-bottom-right-radius: 100px;
@@ -113,7 +113,7 @@
                 z-index: 10;
                 
                 .back-button-text {
-                    @include kanban.bodyMText;
+                    @include kanban.kanbanBodyMText;
                     font-size: 10px;
                     font-weight: lighter;
                     letter-spacing: 1.25px;

--- a/src/app/components/board-form/board-form.component.scss
+++ b/src/app/components/board-form/board-form.component.scss
@@ -13,8 +13,7 @@
         width: 100%;
         
         .title-text {
-            // @include kanban.darkHeadingLText;
-            @include kanban.headingLText;
+            @include kanban.kanbanHeadingLText;
             padding: 0;
         }
    }
@@ -36,7 +35,7 @@
         }
 
         .field-label {
-            @include kanban.bodyMText;
+            @include kanban.kanbanBodyMText;
             color: var(--title-text-1);
         }
 
@@ -51,13 +50,13 @@
             }
 
             .cancel-button {
-                @include kanban.mainButtonStyles(var(--kanban-secondary-idle), var(--kanban-on-secondary-idle), 40px);
+                @include kanban.kanbanMainButtonStyles(var(--kanban-secondary-idle), var(--kanban-on-secondary-idle), 40px);
                 justify-content: center;
                 margin: 4px 0;
             }
 
             .save-button {
-                @include kanban.mainButtonStyles(var(--kanban-primary-idle), var(--kanban-on-primary-idle), 40px);
+                @include kanban.kanbanMainButtonStyles(var(--kanban-primary-idle), var(--kanban-on-primary-idle), 40px);
                 justify-content: center;
                 margin: 4px 0;
             }

--- a/src/app/components/board-view/board-view.component.scss
+++ b/src/app/components/board-view/board-view.component.scss
@@ -28,15 +28,14 @@
             .top-drawer-container {
 
                 .all-boards {
-                    // @include kanban.lightHeadingSText;
-                    @include kanban.headingSText;
+                    @include kanban.kanbanHeadingSText;
                     margin: 16px 0 0;
                     padding: 0 16px;
                     text-transform: uppercase;
                 }
 
                 .nav-button {
-                    @include kanban.sidenavButtonStyles;
+                    @include kanban.kanbanSidenavButtonStyles;
                     @include global.flexboxLayout(row, flex-start, center);
 
                     mat-icon {
@@ -58,10 +57,7 @@
                 
 
                 .create-new-board-button {
-                    // @include kanban.darkHeadingMText;
-                    // background-color: var(--dark-background-3);
-                    // color: var(--primary-idle);
-                    @include kanban.headingMText;
+                    @include kanban.kanbanHeadingMText;
                     background-color: var(--background-3);
                     color: var(--kanban-primary-idle);
                     margin: 4px 8px;
@@ -71,19 +67,15 @@
             .bottom-buttons-container {
                 @include global.flexboxLayout(column, flex-start, center);
                 margin-bottom: 50px;
-                // padding-left: 24px;
                 width: 100%;
                 
                 .dark-mode-switch-container {
                     @include global.flexboxLayout(row, space-between, center);
-                    // background-color: var(--dark-background-2);
                     background-color: var(--background-2);
-                    // margin: 0 24px 22px;
                     margin: 0 0 22px;
                     padding: 15px 64px;
 
                     mat-icon {
-                        // color: var(--light-subtitle-text-1);
                         color: var(--subtitle-text-1);
                     }
 
@@ -93,14 +85,11 @@
                 }
 
                 .hide-sidebar-button {
-                    // @include kanban.darkHeadingMText;
-                    @include kanban.headingMText;
+                    @include kanban.kanbanHeadingMText;
                     @include global.flexboxLayout(row, center, center);
                     align-self: flex-start;
-                    // background-color: var(--dark-background-3);
                     background-color: var(--background-3);
                     border: none;
-                    // color: var(--light-subtitle-text-1);
                     color: var(--subtitle-text-1);
                     cursor: pointer;
                     margin-left: 14px;
@@ -114,14 +103,12 @@
         }
 
         .mat-drawer-content {
-            // background-color: var(--dark-background-2);
             background-color: var(--background-2);
             overflow-y: hidden;
             position: relative;
 
             .nav-bar {
                 @include global.flexboxLayout(row, space-between, center);
-                // background-color: var(--dark-background-3);
                 background-color: var(--background-3);
                 border-bottom: 1px solid var(--sidenav-border-color);
                 height: var(--size-nav-bar-height);
@@ -131,16 +118,8 @@
                     @include global.flexboxLayout(row, flex-start, center);
                     margin: 0 0 0 16px;
         
-                    // .kanban-icon-container {
-                    //     @include global.flexboxLayout(row, flex-start, center);
-                                
-                        
-        
-                    // }
-        
                     .board-title {
-                        // @include kanban.darkHeadingXLText;
-                        @include kanban.headingXLText;
+                        @include kanban.kanbanHeadingXLText;
                         margin: 24px;
                         
                         @include global.response(sm) {
@@ -162,8 +141,7 @@
                     @include global.flexboxLayout(row, flex-start, center);
                     
                     .nav-button {
-                        // @include kanban.topnavButtonStyles(var(--primary-idle), var(--text-color-for-dark-background-1), var(--size-button-tall));
-                        @include kanban.topnavButtonStyles(var(--kanban-primary-idle), var(--kanban-on-primary-idle), var(--size-button-tall));
+                        @include kanban.kanbanTopnavButtonStyles(var(--kanban-primary-idle), var(--kanban-on-primary-idle), var(--size-button-tall));
                         
                         .nav-button-text {
                             margin: 0;
@@ -181,7 +159,7 @@
                         }
         
                         @include global.response(sm) {
-                            @include kanban.topnavButtonStylesMobile;
+                            @include kanban.kanbanTopnavButtonStylesMobile;
                             width: 48px;
                         }
         
@@ -206,8 +184,8 @@
             }
         
             .show-drawer-button {
-                // @include kanban.mainButtonStyles(var(--primary-idle), var(--text-color-for-dark-background-1), var(--size-button-tall));    
-                @include kanban.mainButtonStyles(var(--kanban-primary-idle), var(--kanban-on-primary-idle), var(--size-button-tall));    
+                // @include kanban.kanbanmainButtonStyles(var(--primary-idle), var(--text-color-for-dark-background-1), var(--size-button-tall));    
+                @include kanban.kanbanMainButtonStyles(var(--kanban-primary-idle), var(--kanban-on-primary-idle), var(--size-button-tall));    
                 border-top-left-radius: 0;
                 border-top-right-radius: 100px;
                 border-bottom-right-radius: 100px;
@@ -222,10 +200,8 @@
                     display: none;
                 }
             }
-
         }
     }
-
 }
 
 .kanban-logo-container {
@@ -238,11 +214,10 @@
     @include global.response(sm) {
         border: none;
         margin: 0;
-        // width: 100px;
     }
 
     .logo-text {
-        @include kanban.headingXLText;
+        @include kanban.kanbanHeadingXLText;
         margin: 0 0 0 16px;
 
         @include global.response(sm) {
@@ -310,8 +285,7 @@
             }
 
             .column-header-text {
-                // @include kanban.darkHeadingSText;
-                @include kanban.headingSText;
+                @include kanban.kanbanHeadingSText;
                 // color: var(--light-subtitle-text-1);
                 color: var(--subtitle-text-1);
                 margin: 0;
@@ -330,16 +304,13 @@
         margin-top: 64px;
 
         .new-column-button {
-            // @include kanban.darkHeadingXLText;
-            @include kanban.headingXLText;
-            // color: var(--light-subtitle-text-1);
+            @include kanban.kanbanHeadingXLText;
             color: var(--subtitle-text-1);
             text-transform: capitalize;
             
         }
         
         mat-icon {
-            // color: var(--light-subtitle-text-1);
             color: var(--subtitle-text-1);
             margin-right: 8px;
         }
@@ -348,16 +319,14 @@
 }
 
 .task-card {
-    @include kanban.taskCardStyles;
+    @include kanban.kanbanTaskCardStyles;
     
     .task-title {
-        // @include kanban.darkHeadingMText;
-        @include kanban.headingMText;
+        @include kanban.kanbanHeadingMText;
     }
 
     .task-subtitle {
-        // @include kanban.darkBodyMText;
-        @include kanban.bodyMText;
+        @include kanban.kanbanBodyMText;
     }
     
     
@@ -370,16 +339,13 @@
 }
 
 .empty-board {
-    // @include kanban.darkBodyLText;
-    @include kanban.bodyLText;
-    // color: var(--light-subtitle-text-1);
+    @include kanban.kanbanBodyLText;
     color: var(--subtitle-text-1);
 
 
 }
 
 .add-column-button {
-    @include kanban.mainButtonStyles;
-    // @include kanban.darkHeadingMText;
-    @include kanban.headingMText;
+    @include kanban.kanbanMainButtonStyles;
+    @include kanban.kanbanHeadingMText;
 }

--- a/src/app/components/boards-select/boards-select.component.scss
+++ b/src/app/components/boards-select/boards-select.component.scss
@@ -11,14 +11,14 @@
         margin: 16px 24px 16px 0;
 
         .all-boards {
-            @include kanban.headingSText;
+            @include kanban.kanbanHeadingSText;
             padding: 0 16px;
             text-transform: uppercase;
         }
 
         .nav-button {
             @include global.flexboxLayout(row, flex-start, center);
-            @include kanban.sidenavButtonStyles;
+            @include kanban.kanbanSidenavButtonStyles;
     
             mat-icon {
                 margin: 0 16px 0 0;
@@ -37,7 +37,7 @@
         }
 
         .create-new-board-button {
-            @include kanban.headingMText;
+            @include kanban.kanbanHeadingMText;
             background-color: var(--background-3);
             color: var(--kanban-primary-idle);
             margin: 4px 8px;

--- a/src/app/components/column-settings/column-settings.component.scss
+++ b/src/app/components/column-settings/column-settings.component.scss
@@ -12,13 +12,13 @@
         width: 100%;
         
         .title-text {
-            @include kanban.headingLText;
+            @include kanban.kanbanHeadingLText;
             margin-bottom: 24px;
             padding: 0;
         }
 
         .subtitle-text {
-            @include kanban.bodyMText;
+            @include kanban.kanbanBodyMText;
             padding: 0;
         }
    }
@@ -28,13 +28,13 @@
 
         @include global.response(h-md) {
             margin-bottom: 24px;
-            max-height: 290px;
+            max-height: 262px;
             overflow-y: auto;
         }
 
         @include global.response(h-sm) {
             margin-bottom: 18px;
-            max-height: 145px;
+            max-height: 130px;
             overflow-y: auto;
         }
 
@@ -56,10 +56,21 @@
 
                 .checkbox-container {
                     background-color: var(--checkbox-background);
+                    width: 100%;
+                    border-radius: 4px;
+                    
+                    &:not(:last-child) {
+                        margin-bottom: 4px;
+                        
+                    }
                     
                     &:hover {
                         background-color: var(--checkbox-background-hover);
                         
+                    }
+
+                    mat-icon {
+                        color: var(--title-text-1);
                     }
                 }
 
@@ -83,7 +94,7 @@
         width: 100%;
 
         .all-none-button {
-            @include kanban.mainButtonStyles(var(--kanban-primary-idle), var(--kanban-on-primary-idle), 20px);
+            @include kanban.kanbanMainButtonStyles(var(--kanban-primary-idle), var(--kanban-on-primary-idle), 20px);
             font-size: 12px;
             justify-content: center;
             width: 40%;
@@ -94,7 +105,7 @@
         }
 
         .reset-initial-button {
-            @include kanban.mainButtonStyles(var(--kanban-primary-idle), var(--kanban-on-primary-idle), 20px);
+            @include kanban.kanbanMainButtonStyles(var(--kanban-primary-idle), var(--kanban-on-primary-idle), 20px);
             font-size: 12px;
             justify-content: center;
             width: 40%;
@@ -120,12 +131,12 @@
 
         
         .cancel-button {
-            @include kanban.mainButtonStyles(var(--kanban-secondary-idle), var(--kanban-on-secondary-idle), 40px);
+            @include kanban.kanbanMainButtonStyles(var(--kanban-secondary-idle), var(--kanban-on-secondary-idle), 40px);
             justify-content: center;
         }
         
         .save-button {
-            @include kanban.mainButtonStyles(var(--kanban-primary-idle), var(--kanban-on-primary-idle), 40px);
+            @include kanban.kanbanMainButtonStyles(var(--kanban-primary-idle), var(--kanban-on-primary-idle), 40px);
             justify-content: center;
         }
     }
@@ -150,7 +161,7 @@
     }
     
     .element-title {
-        @include kanban.bodyMText;
+        @include kanban.kanbanBodyMText;
     }
 
     p {
@@ -174,7 +185,7 @@
                 0 3px 14px 2px rgba(0, 0, 0, 0.12);
 
     .element-title {
-        @include kanban.bodyMText;
+        @include kanban.kanbanBodyMText;
     }
 
     p {

--- a/src/app/components/delete-confirm/delete-confirm.component.scss
+++ b/src/app/components/delete-confirm/delete-confirm.component.scss
@@ -4,7 +4,6 @@
 
 .delete-dialog-container {
     @include global.flexboxLayout(column, flex-start, flex-start);
-    // background-color: var(--dark-background-3);
     background-color: var(--background-3);
     
     .title-container {
@@ -13,18 +12,14 @@
         width: 100%;
 
         .title-text {
-            // @include kanban.darkHeadingLText;
-            // color: var(--destructive-idle);
-            @include kanban.headingLText;
+            @include kanban.kanbanHeadingLText;
             color: var(--kanban-destructive-idle);
             padding: 0;
         }
     }
 
     .message {
-        // @include kanban.darkBodyLText;
-        // color: var(--light-subtitle-text-1);
-        @include kanban.bodyLText;
+        @include kanban.kanbanBodyLText;
         color: var(--subtitle-text-1);
         margin: 0 0 24px;
 
@@ -49,14 +44,12 @@
         }
 
         .cancel-button {
-            // @include kanban.mainButtonStyles(var(--secondary-idle), var(--text-color-for-light-background-1), 40px);
-            @include kanban.mainButtonStyles(var(--kanban-secondary-idle), var(--kanban-on-secondary-idle), 40px);
+            @include kanban.kanbanMainButtonStyles(var(--kanban-secondary-idle), var(--kanban-on-secondary-idle), 40px);
             justify-content: center;
         }
         
         .delete-button {
-            // @include kanban.mainButtonStyles(var(--destructive-idle), var(--text-color-for-dark-background-1), 40px);
-            @include kanban.mainButtonStyles(var(--kanban-destructive-idle), var(--kanban-on-destructive-idle), 40px);
+            @include kanban.kanbanMainButtonStyles(var(--kanban-destructive-idle), var(--kanban-on-destructive-idle), 40px);
             justify-content: center;
         }
     }

--- a/src/app/components/design-system/design-system.component.scss
+++ b/src/app/components/design-system/design-system.component.scss
@@ -95,7 +95,7 @@
                 flex-wrap: wrap;
                 
                 .button {
-                    @include kanban.mainButtonStyles;
+                    @include kanban.kanbanMainButtonStyles;
                 }
                 
                 .button-1 {
@@ -165,7 +165,7 @@
                     }
 
                     .checkbox-label {
-                        @include kanban.bodyMText;
+                        @include kanban.kanbanBodyMText;
                         display: block;
 
                     }
@@ -225,23 +225,23 @@
             background-color: var(--light-background-1);
     
             .light-heading-xl{
-                @include kanban.headingXLText;
+                @include kanban.kanbanHeadingXLText;
                 
             }
             .light-heading-l{
-                @include kanban.headingLText;
+                @include kanban.kanbanHeadingLText;
             }
             .light-heading-m{
-                @include kanban.headingMText;
+                @include kanban.kanbanHeadingMText;
             }
             .light-heading-s{
-                @include kanban.headingSText;
+                @include kanban.kanbanHeadingSText;
             }
             .light-body-l{
-                @include kanban.bodyLText;
+                @include kanban.kanbanBodyLText;
             }
             .light-body-m{
-                @include kanban.bodyMText;
+                @include kanban.kanbanBodyMText;
             }
         }
     
@@ -249,23 +249,23 @@
             background-color: var(--dark-background-1);
     
             .dark-heading-xl{
-                @include kanban.headingXLText;
+                @include kanban.kanbanHeadingXLText;
                 
             }
             .dark-heading-l{
-                @include kanban.headingLText;
+                @include kanban.kanbanHeadingLText;
             }
             .dark-heading-m{
-                @include kanban.headingMText;
+                @include kanban.kanbanHeadingMText;
             }
             .dark-heading-s{
-                @include kanban.headingSText;
+                @include kanban.kanbanHeadingSText;
             }
             .dark-body-l{
-                @include kanban.bodyLText;
+                @include kanban.kanbanBodyLText;
             }
             .dark-body-m{
-                @include kanban.bodyMText;
+                @include kanban.kanbanBodyMText;
             }
         }
 

--- a/src/app/components/kanban-tasks/kanban-tasks.component.scss
+++ b/src/app/components/kanban-tasks/kanban-tasks.component.scss
@@ -33,7 +33,7 @@
                 }
 
                 .column-header-text {
-                    @include kanban.headingSText;
+                    @include kanban.kanbanHeadingSText;
                     color: var(--subtitle-text-1);
                     margin: 0;
                     text-transform: uppercase;
@@ -50,7 +50,7 @@
             width: 100%;
 
             .new-column-button {
-                @include kanban.headingXLText;
+                @include kanban.kanbanHeadingXLText;
                 color: var(--subtitle-text-1);
                 text-transform: capitalize;
                 white-space: normal;
@@ -70,13 +70,13 @@
     height: calc(100% - var(--size-nav-bar-height));
 
     .empty-board {
-        @include kanban.headingLText;
+        @include kanban.kanbanHeadingLText;
         color: var(--subtitle-text-1);
     }
 
     .add-column-button {
-        @include kanban.mainButtonStyles;
-        @include kanban.headingMText;
+        @include kanban.kanbanMainButtonStyles;
+        @include kanban.kanbanHeadingMText;
     }
 
 }
@@ -84,7 +84,7 @@
 // this is the same element as .cdk-drag.  It is NOT the element as it is being dragged.
 // it is the card in the drag-from location
 .task-card {
-    @include kanban.taskCardStyles;
+    @include kanban.kanbanTaskCardStyles;
 
     // this properly applies styles for light/dark themes for the source
     // card.  However, the dragged element only gets the color if a static value is used.

--- a/src/app/components/task-form/task-form.component.scss
+++ b/src/app/components/task-form/task-form.component.scss
@@ -12,7 +12,7 @@
         width: 100%;
         
         .title-text {
-            @include kanban.headingLText;
+            @include kanban.kanbanHeadingLText;
             margin: 0;
             padding: 0;
         }
@@ -38,7 +38,7 @@
         }
 
         .field-label {
-            @include kanban.bodyMText;
+            @include kanban.kanbanBodyMText;
             color: var(--title-text-1);
         }
 
@@ -80,7 +80,7 @@
         }
 
         .add-subtask-button {
-            @include kanban.mainButtonStyles(var(--kanban-secondary-idle), var(--kanban-on-secondary-idle), 40px);
+            @include kanban.kanbanMainButtonStyles(var(--kanban-secondary-idle), var(--kanban-on-secondary-idle), 40px);
             justify-content: center;
             margin: 0 0 24px;
             width: 100%;
@@ -104,12 +104,12 @@
                 width: 50%;
             }
             .cancel-button {
-                @include kanban.mainButtonStyles(var(--kanban-secondary-idle), var(--kanban-on-secondary-idle), 40px);
+                @include kanban.kanbanMainButtonStyles(var(--kanban-secondary-idle), var(--kanban-on-secondary-idle), 40px);
                 justify-content: center;
             }
     
             .save-button {
-                @include kanban.mainButtonStyles(var(--kanban-primary-idle), var(--kanban-on-primary-idle), 40px);
+                @include kanban.kanbanMainButtonStyles(var(--kanban-primary-idle), var(--kanban-on-primary-idle), 40px);
                 justify-content: center;
             }
      

--- a/src/app/components/view-task/view-task.component.scss
+++ b/src/app/components/view-task/view-task.component.scss
@@ -14,7 +14,7 @@
         width: 100%;
         
         .mat-mdc-dialog-title {
-            @include kanban.headingLText;
+            @include kanban.kanbanHeadingLText;
             margin: 0;
             max-width: 300px;
             padding: 0;
@@ -31,7 +31,7 @@
 
 
     .dialog-subtitle {
-        @include kanban.bodyLText;
+        @include kanban.kanbanBodyLText;
         color: var(--subtitle-text-1);
         margin-bottom: 24px;
     }
@@ -42,7 +42,7 @@
         width: 100%;
 
         .subtasks-header {
-            @include kanban.bodyMText;
+            @include kanban.kanbanBodyMText;
             color: var(--subtitle-text-1);
             margin-bottom: 16px;
         }
@@ -69,7 +69,7 @@
                 }
         
                 .subtask-description {
-                    @include kanban.bodyMText;
+                    @include kanban.kanbanBodyMText;
                     margin: 0;
                 }
             }
@@ -88,7 +88,7 @@
             padding: 8px 16px;
 
             &-text {
-                @include kanban.bodyLText;
+                @include kanban.kanbanBodyLText;
                 margin: 0;
             }
         }
@@ -99,7 +99,7 @@
         width: 100%;
 
         button {
-            @include kanban.mainButtonStyles;
+            @include kanban.kanbanMainButtonStyles;
             color: var(--kanban-on-primary-idle);
             padding: 4px 24px;
         }

--- a/src/styles/_kanban-mixins.scss
+++ b/src/styles/_kanban-mixins.scss
@@ -2,7 +2,7 @@
 @use './kanban-variables' as kanbanVar;
 
 //////////////// ELEMENTS //////////////////////
-@mixin mainButtonStyles($background-color: var(--kanban-primary-idle), $color: var(--kanban-on-primary-idle), $height: var(--size-button-regular)) {
+@mixin kanbanMainButtonStyles($background-color: var(--kanban-primary-idle), $color: var(--kanban-on-primary-idle), $height: var(--size-button-regular)) {
     @include global.flexboxLayout(row, space-between, center);
     background-color: $background-color;
     border: none;
@@ -13,8 +13,8 @@
     padding: 0 24px;
 }
 
-@mixin topnavButtonStyles($background-color: var(--kanban-primary-idle), $color: var(--kanban-on-primary-idle), $height: var(--size-button-regular)) {
-    @include headingMText;
+@mixin kanbanTopnavButtonStyles($background-color: var(--kanban-primary-idle), $color: var(--kanban-on-primary-idle), $height: var(--size-button-regular)) {
+    @include kanbanHeadingMText;
     @include global.flexboxLayout(row, space-between, center);
     background-color: $background-color;
     border: none;
@@ -25,8 +25,8 @@
     padding: 0 24px;
 }
 
-@mixin topnavButtonStylesMobile {
-    @include topnavButtonStyles;
+@mixin kanbanTopnavButtonStylesMobile {
+    @include kanbanTopnavButtonStyles;
     @include global.flexboxLayout(row, center, center);
     height: var(--size-button-mobile-height);
     min-width: 0;
@@ -34,8 +34,8 @@
     width: var(--size-button-mobile-width);
 }
 
-@mixin sidenavButtonStyles {
-    @include headingMText;
+@mixin kanbanSidenavButtonStyles {
+    @include kanbanHeadingMText;
     background-color: var(--background-3);
     border: none;
     border-top-right-radius: 24px;
@@ -50,12 +50,12 @@
     width: 276px;
 }
 
-@mixin sidenavButtonStylesMobile {
-    @include sidenavButtonStyles();
+@mixin kanbanSidenavButtonStylesMobile {
+    @include kanbanSidenavButtonStyles();
     width: 240px;
 }
 
-@mixin taskCardStyles {
+@mixin kanbanTaskCardStyles {
     @include global.flexboxLayout(row, flex-start, flex-start);
     background-color: var(--background-3);
     border-radius: 8px;
@@ -79,12 +79,12 @@
         width: 100%;
 
         .task-title {
-            @include headingMText;
+            @include kanbanHeadingMText;
             margin: 0 0 8px;
         }
     
         .task-subtitle {
-            @include bodyMText;
+            @include kanbanBodyMText;
             margin: 0 0 6px;
         }
     }
@@ -94,7 +94,7 @@
 
 ////////////// TYPOGRAPHY //////////////////////////
 
-@mixin headingXLText {
+@mixin kanbanHeadingXLText {
     color: var(--title-text-1);
     font-weight: 700;
     font-size: kanbanVar.fontSize(heading-xl);
@@ -112,7 +112,7 @@
     }
 }
 
-@mixin headingLText {
+@mixin kanbanHeadingLText {
     color: var(--title-text-1);
     font-weight: 700;
     font-size: kanbanVar.fontSize(heading-lg);
@@ -120,7 +120,7 @@
     font-family: var(--main-font-family), "Helvetica Neue", sans-serif;
 }
 
-@mixin headingMText {
+@mixin kanbanHeadingMText {
     color: var(--title-text-1);
     font-weight: 700;
     font-size: kanbanVar.fontSize(heading-md);
@@ -128,7 +128,7 @@
     font-family: var(--main-font-family), "Helvetica Neue", sans-serif;
 }
 
-@mixin headingSText {
+@mixin kanbanHeadingSText {
     color: var(--subtitle-text-1);
     font-weight: 700;
     font-size: kanbanVar.fontSize(heading-sm);
@@ -136,7 +136,7 @@
     font-family: var(--main-font-family), "Helvetica Neue", sans-serif;
 }
 
-@mixin bodyLText {
+@mixin kanbanBodyLText {
     color: var(--title-text-3);
     font-weight: 500;
     font-size: kanbanVar.fontSize(body-l);
@@ -144,7 +144,7 @@
     font-family: var(--main-font-family), "Helvetica Neue", sans-serif;
 }
 
-@mixin bodyMText {
+@mixin kanbanBodyMText {
     color: var(--title-text-3);
     font-weight: 700;
     font-size: kanbanVar.fontSize(body-m);

--- a/src/styles/_ng-exp-mixins.scss
+++ b/src/styles/_ng-exp-mixins.scss
@@ -1,6 +1,71 @@
 @use './global-mixins' as global;
 @use './ng-exp-variables' as angExpVar;
 
+
+////////////// TYPOGRAPHY //////////////////////////
+
+@mixin headingXLText {
+    color: var(--ang-exp-title-text-1);
+    font-weight: 700;
+    font-size: angExpVar.fontSize(heading-xl);
+    line-height: angExpVar.lineHeight(heading-xl);
+    font-family: var(--ang-exp-main-font-family), "Helvetica Neue", sans-serif;
+
+    @include global.response(md) {
+        font-size: angExpVar.fontSize(tablet-heading-xl);
+        line-height: angExpVar.lineHeight(heading-lg);
+    }
+    
+    @include global.response(sm) {
+        font-size: angExpVar.fontSize(heading-lg);
+        line-height: angExpVar.lineHeight(heading-lg);
+    }
+}
+
+@mixin headingLText {
+    color: var(--ang-exp-title-text-1);
+    font-weight: 700;
+    font-size: angExpVar.fontSize(heading-lg);
+    line-height: angExpVar.lineHeight(heading-lg);
+    font-family: var(--ang-exp-main-font-family), "Helvetica Neue", sans-serif;
+}
+
+@mixin headingMText {
+    color: var(--ang-exp-title-text-1);
+    font-weight: 700;
+    font-size: angExpVar.fontSize(heading-md);
+    line-height: angExpVar.lineHeight(heading-md);
+    font-family: var(--ang-exp-main-font-family), "Helvetica Neue", sans-serif;
+}
+
+@mixin headingSText {
+    color: var(--ang-exp-subtitle-text-1);
+    font-weight: 700;
+    font-size: angExpVar.fontSize(heading-sm);
+    line-height: angExpVar.lineHeight(heading-sm);
+    font-family: var(--ang-exp-main-font-family), "Helvetica Neue", sans-serif;
+}
+
+@mixin bodyLText {
+    color: var(--ang-exp-title-text-3);
+    font-weight: 500;
+    font-size: angExpVar.fontSize(body-l);
+    line-height: angExpVar.lineHeight(body-l);
+    font-family: var(--ang-exp-main-font-family), "Helvetica Neue", sans-serif;
+}
+
+@mixin bodyMText {
+    color: var(--ang-exp-title-text-3);
+    font-weight: 700;
+    font-size: angExpVar.fontSize(body-m);
+    line-height: angExpVar.lineHeight(body-m);
+    font-family: var(--ang-exp-main-font-family), "Helvetica Neue", sans-serif;
+}
+
+
+////////////// END TYPOGRAPHY //////////////////////
+
+
 //////////////// ELEMENTS //////////////////////
 @mixin mainButtonStyles($background-color: var(--ang-exp-primary-idle), $color: var(--ang-exp-on-primary-idle), $height: var(--size-button-regular)) {
     @include global.flexboxLayout(row, space-between, center);
@@ -57,13 +122,13 @@
 
 @mixin taskCardStyles {
     @include global.flexboxLayout(row, flex-start, flex-start);
-    background-color: var(--background-3);
+    background-color: var(--ang-exp-background-3);
     border-radius: 8px;
     box-sizing: border-box;
-    box-shadow: 2px 4px 6px rgba(54, 78, 126, var(--task-card-drop-shadow-opacity));
+    box-shadow: 2px 4px 6px rgba(54, 78, 126, var(--ang-exp-task-card-drop-shadow-opacity));
 
     // this affects the drag handle only
-    color: var(--title-text-1);
+    color: var(--ang-exp-title-text-1);
 
     cursor: pointer;
     margin-bottom: 10px;
@@ -91,66 +156,3 @@
 }
 
 //////////////// END ELEMENTS //////////////////////
-
-////////////// TYPOGRAPHY //////////////////////////
-
-@mixin headingXLText {
-    color: var(--title-text-1);
-    font-weight: 700;
-    font-size: angExpVar.fontSize(heading-xl);
-    line-height: angExpVar.lineHeight(heading-xl);
-    font-family: var(--main-font-family), "Helvetica Neue", sans-serif;
-
-    @include global.response(md) {
-        font-size: angExpVar.fontSize(tablet-heading-xl);
-        line-height: angExpVar.lineHeight(heading-lg);
-    }
-    
-    @include global.response(sm) {
-        font-size: angExpVar.fontSize(heading-lg);
-        line-height: angExpVar.lineHeight(heading-lg);
-    }
-}
-
-@mixin headingLText {
-    color: var(--title-text-1);
-    font-weight: 700;
-    font-size: angExpVar.fontSize(heading-lg);
-    line-height: angExpVar.lineHeight(heading-lg);
-    font-family: var(--main-font-family), "Helvetica Neue", sans-serif;
-}
-
-@mixin headingMText {
-    color: var(--title-text-1);
-    font-weight: 700;
-    font-size: angExpVar.fontSize(heading-md);
-    line-height: angExpVar.lineHeight(heading-md);
-    font-family: var(--main-font-family), "Helvetica Neue", sans-serif;
-}
-
-@mixin headingSText {
-    color: var(--subtitle-text-1);
-    font-weight: 700;
-    font-size: angExpVar.fontSize(heading-sm);
-    line-height: angExpVar.lineHeight(heading-sm);
-    font-family: var(--main-font-family), "Helvetica Neue", sans-serif;
-}
-
-@mixin bodyLText {
-    color: var(--title-text-3);
-    font-weight: 500;
-    font-size: angExpVar.fontSize(body-l);
-    line-height: angExpVar.lineHeight(body-l);
-    font-family: var(--main-font-family), "Helvetica Neue", sans-serif;
-}
-
-@mixin bodyMText {
-    color: var(--title-text-3);
-    font-weight: 700;
-    font-size: angExpVar.fontSize(body-m);
-    line-height: angExpVar.lineHeight(body-m);
-    font-family: var(--main-font-family), "Helvetica Neue", sans-serif;
-}
-
-
-////////////// END TYPOGRAPHY //////////////////////

--- a/src/styles/_ng-exp-variables.scss
+++ b/src/styles/_ng-exp-variables.scss
@@ -1,5 +1,7 @@
 
 :root {
+    --ang-exp-purple-1: #635fc7;
+    --ang-exp-purple-2: #a8a4ff;
     --ang-exp-grey-1: #000112;
     --ang-exp-grey-2: #20212c;
     --ang-exp-grey-3: #2b2c37;
@@ -25,6 +27,21 @@
     --ang-exp-on-destructive-hover: var(--ang-exp-white-1);
 
     --ang-exp-size-nav-bar-height: 96px;
+
+     // --font-plus-jakarta-sans: Plus Jakarta sans, "Helvetica Neue", sans-serif;
+    //  --font-plus-jakarta-sans: Plus Jakarta sans;
+     --font-kanit: Kanit, "Helvetica Neue", sans-serif;
+     --font-josefin-sans: Josefin sans, "Helvetica Neue", sans-serif;
+     // --font-great-vibes: Great Vibes, "Helvetica Neue", sans-serif;
+     // --font-dancing-script: Dancing Script, "Helvetica Neue", sans-serif;
+     // --font-nunito: Nunito, "Helvetica Neue", sans-serif;
+     
+    //  --main-font-family: var(--font-plus-jakarta-sans);
+    // --main-font-family: var(--font-kanit);
+    --ang-exp-main-font-family: var(--font-josefin-sans);
+    // --main-font-family: var(--font-great-vibes);
+    // --main-font-family: var(--font-dancing-script);
+    // --main-font-family: var(--font-nunito);
 }
 
 


### PR DESCRIPTION
-Even with explicit imports (@use "../styles/ng-exp-mixins" as ang-exp @include ang-exp.headingXLText), the sass was picking up the mixin name from kanban mixins if they were the same
-prefixed all kanban mixins with 'kanban' and updated mixin refs with the new mixin name
-ang-exp mixins did not get updated names
-Also added logic in AngExp component to style the sidenav button