### PR TITLE
Implements logic to only show boards/tasks owned by the logged in user

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,6 +2,22 @@ rules_version = '2';
 service cloud.firestore {
     match /databases/{database}/documents {
 
+        function hasRequest() {
+            return request;
+        }
+
+        function hasAuth() {
+            return request.auth.uid;
+        }
+
+        function hasResource() {
+            return request.resource;
+        }
+        
+        function hasData() {
+            return request.resource.data['ownerUid'];
+        }
+
         function isAuthenticated() {
             return request.auth.uid != null;
         }
@@ -17,12 +33,16 @@ service cloud.firestore {
 
         match /boards/{boardId} {
             allow read: if isAuthenticated();
-            allow write: if isAuthenticated();
+            allow create: if debug(debug(isOwnedByUser()));
+            allow update: if debug(debug(isOwnedByUser()));
+            allow delete: if debug(debug(isAuthenticated()));
             
 
             match /tasks/{taskId} {
                 allow read: if isAuthenticated();
-                allow write: if isAuthenticated();
+                allow create: if isOwnedByUser();
+                allow update: if isOwnedByUser();
+                allow delete: if isAuthenticated();
             }
         }
     }

--- a/src/app/comps/login-reg/login-reg.component.ts
+++ b/src/app/comps/login-reg/login-reg.component.ts
@@ -1,13 +1,11 @@
-import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit} from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit} from '@angular/core';
 import {Router} from '@angular/router';
-import { Subscription } from 'rxjs';
-
-import { Auth, authState, idToken,  User, user } from '@angular/fire/auth';
+import { Auth, User, user } from '@angular/fire/auth';
 // from https://github.com/firebase/firebaseui-web
 import * as firebaseui from 'firebaseui';
 import firebase from 'firebase/compat/app';
 // See https://github.com/angular/angularfire/blob/master/docs/auth.md
-import { getAuth, onAuthStateChanged, signInAnonymously,  signInWithPopup, GoogleAuthProvider } from "firebase/auth";
+import { onAuthStateChanged, signInAnonymously, GoogleAuthProvider } from "firebase/auth";
 
 import { LOGIN_INSTRUCTIONS } from '../../common/constants';
 
@@ -22,14 +20,6 @@ export class LoginRegComponent implements OnDestroy, OnInit {
   
   provider = new GoogleAuthProvider();
 
-  // user$ = user(this.auth);
-  // userSubscription: Subscription;
-  // authState$ = authState(this.auth);
-  // authStateSubscription: Subscription;
-  // idToken$ = idToken(this.auth);
-  // idTokenSubscription: Subscription;
-
-  
   ////////////// FIREBASEUI ////////////////
   // from https://firebase.google.com/docs/auth/web/firebaseui near bottom
 
@@ -46,10 +36,8 @@ export class LoginRegComponent implements OnDestroy, OnInit {
       return true;
     }
     
-    signInFailure = (error: firebaseui.auth.AuthUIError) => {
-      
-      console.log('lR sIF auth error: ', error);
-      
+  signInFailure = (error: firebaseui.auth.AuthUIError) => {
+    // console.log('lR sIF auth error: ', error);
   };
   
   firebaseuiConfig: firebaseui.auth.Config = {
@@ -57,22 +45,11 @@ export class LoginRegComponent implements OnDestroy, OnInit {
     // from firebaseui docs
     callbacks: {
       signInSuccessWithAuthResult: this.signInSuccessWithAuthResult,
-      // The widget is rendered.
-      // Hide the loader.
-      // uiShown: function () {document.getElementById('loader')?.style.display = 'none';},
-
       signInFailure: this.signInFailure,
     },
 
-    // from ang-u-fb-course
-    // also works
-    // callbacks: {
-    //   signInSuccessWithAuthResult: this.onLoginSuccessful.bind(this),
-    // },
-
     signInFlow: 'redirect',
     signInSuccessUrl: '/kanban',
-    // signInSuccessUrl: '/login',
     signInOptions: [
       {
         provider: firebase.auth.EmailAuthProvider.PROVIDER_ID,
@@ -83,88 +60,49 @@ export class LoginRegComponent implements OnDestroy, OnInit {
       firebase.auth.TwitterAuthProvider.PROVIDER_ID,
       firebase.auth.GithubAuthProvider.PROVIDER_ID
     ],
-    // autoUpgradeAnonymousUsers: true,
     tosUrl: '',
     privacyPolicyUrl: '',
   };
 
-  // ui = new firebaseui.auth.AuthUI(firebase.auth());
   ui: firebaseui.auth.AuthUI;
 
   ///////////////////////////////////////////
 
   readonly LOGIN_INSTRUCTIONS = LOGIN_INSTRUCTIONS;
 
-  constructor(private auth: Auth, readonly router: Router) {
-    // this.userSubscription = this.user$.subscribe((aUser: User | null) => {
-    //   //handle user state changes here. Note, that user will be null if there is no currently logged in user.
-    //   console.log('lR ctor user subscription: ',aUser);
-    // });
-
-    // this.authStateSubscription = this.authState$.subscribe((aUser: User | null) => {
-    //   //handle auth state changes here. Note, that user will be null if there is no currently logged in user.
-    //   console.log('lR ctor auth state subscription: ',aUser);
-    // });
-
-    // this.idTokenSubscription = this.idToken$.subscribe((token: string | null) => {
-    //   //handle idToken changes here. Note, that user will be null if there is no currently logged in user.
-    //   console.log('lR ctor id token subscription: ', token);
-    // });
-
-  }
+  constructor(private auth: Auth, readonly router: Router) {}
 
   ngOnInit(): void {
-    // this.ui = new firebaseui.auth.AuthUI(firebase.auth());
     this.ui = new firebaseui.auth.AuthUI(this.auth);
     this.ui.start('#firebaseui-auth-container', this.firebaseuiConfig);
     this.ui.disableAutoSignIn();
-    
-    if (this.ui.isPendingRedirect()) {
-      // this.ui = new firebaseui.auth.AuthUI(this.auth);
-      // this.ui.start('#firebaseui-auth-container', this.firebaseuiConfig);
-      // ui.start('#firebaseui-auth-container', uiConfig);
-    }
-
   }
 
   ngOnDestroy() {
-    // this.userSubscription.unsubscribe();
-    // this.authStateSubscription.unsubscribe();
-    // this.idTokenSubscription.unsubscribe();
-
     this.ui.delete();
   }
 
   signInAnonymously() {
     signInAnonymously(this.auth)
     .then(() => {
-      console.log('lR sIA anon login success');
+      // console.log('lR sIA anon login success');
 
     })
     .catch((error) => {
       const errorCode = error.code;
       const errorMessage = error.message;
-      console.log('lR sIA anon login error code/message: ', errorCode, errorMessage);
+      // console.log('lR sIA anon login error code/message: ', errorCode, errorMessage);
     });
 
     onAuthStateChanged(this.auth, (user) => {
       if (user) {
-        const uid = user.uid;
-        console.log('lR sIA anon userId/user: ', uid, user)
+        // const uid = user.uid;
+        // console.log('lR sIA anon userId/user: ', uid, user)
       } else {
-        console.log('lR sIA anon user malfunction - wtf???')
+        // console.log('lR sIA anon user malfunction - wtf???')
       }
-      console.log('lR sIA this.auth.currentUser: ', this.auth.currentUser)
+      // console.log('lR sIA this.auth.currentUser: ', this.auth.currentUser)
     });
     this.router.navigateByUrl('kanban');
   }
-  
-  // onLoginSuccessful(result: any):boolean {
-  //   const user = result.user.uid;
-  //   console.log('lR oLS login success result: ', {...result});
-  //   console.log('lR oLS user: ', user);
-
-  //   return true;
-  // }
-
 }

--- a/src/app/mods/kanban/comps/board-form/board-form.component.ts
+++ b/src/app/mods/kanban/comps/board-form/board-form.component.ts
@@ -2,12 +2,12 @@ import { ChangeDetectionStrategy, Component, Inject, OnDestroy, OnInit } from '@
 import { FormControl, FormGroup } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
+import { User } from '@angular/fire/auth';
 
 import { BoardsStore } from 'src/app/services/boards-store.service';
 import { Board, DialogCloseResult, DialogData, FormMode, TaskStatus} from '../../../../common/interfaces';
 import { BOARD_INITIALIZER } from 'src/app/common/constants';
 import { UserService } from 'src/app/services/user.service';
-import { User } from 'firebase/auth';
 
 @Component({
   selector: 'app-board-form',
@@ -38,12 +38,6 @@ export class BoardFormComponent implements OnDestroy, OnInit {
               public dialogRef: MatDialogRef<BoardFormComponent>,
               @Inject(MAT_DIALOG_DATA) public data: DialogData,
   ) {
-
-    // super();
-
-    // this.theme = data.theme ? data.theme : 'kanban-light-theme';
-
-    // console.log('bF ctor theme from dialog shell/dialog data: ', this.theme, data.theme);
 
     this.buildBoardForm();
     // console.log('bF ctor dialog data: ', data);

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
-import { map, Observable, Subscription } from 'rxjs';
+import { map, Observable } from 'rxjs';
 
-import { Auth, authState, idToken,  User, user } from '@angular/fire/auth';
+import { Auth, authState, idToken, user } from '@angular/fire/auth';
 
 @Injectable({
   providedIn: 'root'
@@ -20,34 +20,9 @@ export class UserService {
 
     this.isLoggedIn$ = this.authState$.pipe(map(user => !!user));
     this.isLoggedOut$ = this.authState$.pipe(map(user => !user));
-
-    // this.userSubscription = this.user$.subscribe((aUser: User | null) => {
-    //   //handle user state changes here. Note, that user will be null if there is no currently logged in user.
-    //   console.log('uS ctor user subscription: ',aUser);
-    // });
-
-    // this.authStateSubscription = this.authState$.subscribe((aUser: User | null) => {
-    //   //handle auth state changes here. Note, that user will be null if there is no currently logged in user.
-    //   console.log('uS ctor auth state subscription: ',aUser);
-    // });
-
-    // this.idTokenSubscription = this.idToken$.subscribe((token: string | null) => {
-    //   //handle idToken changes here. Note, that user will be null if there is no currently logged in user.
-    //   console.log('uS ctor id token subscription: ', token);
-    // });
-
-   }
-
-   ngOnDestroy() {
-    // this.userSubscription.unsubscribe();
-    // this.authStateSubscription.unsubscribe();
-    // this.idTokenSubscription.unsubscribe();
-
-    
   }
 
   logout() {
-    console.log('uS l logging out');
     this.auth.signOut();
   }
 }


### PR DESCRIPTION
-Adds firestore rules for read create, update and delete boards and tasks
-Adds BoardsStore effect to get boards for the logged in user
-Adds BoardsService method to fetch boards for the logged in user
-UI now only shows boards/tasks that belong to the logged in user
NOTE: there's a bug when creating a board for an anonymous user.  After
creating the board, code execution abruptly stops at the call to the store
get all boards for user method.  UI doesn't show the created board. 
Reloading the browser resumes code execution exactly where it ended
and then the board is shown.  Creating boards for users logged in with 
any other method (email, google etc.) work as expected.